### PR TITLE
Registering permissions for user management.

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -30,6 +30,15 @@ class Plugin extends PluginBase
         ];
     }
 
+    /* register permissions */
+
+    public function registerPermissions()
+    {
+        return [
+            'laminsanneh.fantasticfaq.access_faqgroups'       => ['tab' => 'Fantastic FAQ', 'label' => 'Manage the FAQs']
+        ];
+    }
+
     public function registerNavigation()
     {
         return [


### PR DESCRIPTION
Thank you for the plugin, it's great and very useful.  Unfortunately it lacks permission registration to go along with the required permissions defined within the controller, so when you add new users with modified permissions they cannot access the FAQ pages.

I've modified Plugin.php with the relevant permissions.

![screen shot 2015-02-25 at 19 19 55](https://cloud.githubusercontent.com/assets/1913241/6378655/9fe142b0-bd24-11e4-8bce-de1896b898f0.png)
