### PR TITLE
Trying to remove an FAQ answer from a group causes a foreign key error

### DIFF
--- a/updates/group_id_is_nullable.php
+++ b/updates/group_id_is_nullable.php
@@ -1,0 +1,17 @@
+<?php namespace LaminSanneh\FantasticFaq\Updates;
+	
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class GroupIdIsNullable extends Migration
+{
+    public function up()
+    {
+        
+        Schema::table('laminsanneh_fantasticfaq_questions', function($table)
+		{
+		    $table->integer('group_id')->unsigned()->nullable()->change();
+		});
+        
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -12,3 +12,6 @@
   - Register Permission for user management
 1.0.6:
   - Fixed upgrade/broken changes bug introduced by laravel 5 upgrade
+1.0.7:
+  - Fixing FOREIGN KEY error when removing FAQ question from FAQ group by making group_id nullable
+  - group_id_is_nullable.php


### PR DESCRIPTION
This commit changes group_id within laminsanneh_fantasticfaq_questions to be nullable to resolve the title issue.

Screenshot:

![screen shot 2015-03-09 at 20 34 41](https://cloud.githubusercontent.com/assets/1913241/6563813/12796214-c69c-11e4-9e2c-92a63aa376da.png)
